### PR TITLE
Adding system environment variables

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -27,6 +27,9 @@ config :snowflake,
   nodes: ["127.0.0.1"],
   epoch: 1_577_836_800_000
 
+config :profile_place,
+  db_url: System.get_env("DATABASE_URL")
+
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.
 import_config "#{Mix.env()}.exs"


### PR DESCRIPTION
Moved the `secret.exs` file configuration to the `config.exs`. Currently reading `DATABASE_URL` as a system env. variable. MongoDB work has not yet been tested. (no tests exist as of yet)